### PR TITLE
adds screening button component and adds and removes screening times

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { ApicallService } from './apicall.service';
 import { IntroComponent } from './intro/intro.component';
 import { HeaderInterceptor } from './auth-interceptor';
 import { DeferLoadModule } from '@trademe/ng-defer-load';
+import { ScreenButtonComponent } from './screen-button/screen-button.component';
 
 @NgModule({
   declarations: [
@@ -31,7 +32,8 @@ import { DeferLoadModule } from '@trademe/ng-defer-load';
     MovieCardComponent,
     IterablePipe,
     FinalRankingComponent,
-    IntroComponent
+    IntroComponent,
+    ScreenButtonComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/event.service.ts
+++ b/src/app/event.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Movies, MovieItem, PopMovies, PopMovieItem, EWMovies, EWMovieItem } from './movies';
+import { Movies, MovieItem, PopMovies, PopMovieItem, EWMovies, EWMovieItem, Shows, Screening } from './movies';
 
 @Injectable({
   providedIn: 'root'
@@ -30,6 +30,44 @@ export class EventService {
     console.log(this.movies);
   }
 
+  addScreeningToEvent(movie: EWMovieItem, screening: Screening) {
+    let film : EWMovieItem = this.deepCopy<EWMovieItem>(movie);
+    let selection: Screening = this.deepCopy<Screening>(screening);
+
+    if (movie) {
+      console.log("movie: " + movie.title);
+    }
+
+    if (!this.movies.includes(film)) {
+        film.shows[0].show = [selection];
+        console.log("f", film);
+        console.log("m", movie);
+        this.movies.push(film);
+        //movie.shows.push(screening);
+    } else {
+      //movie.shows.push(screening);
+      film.shows[0].show?.push(selection);
+    }
+    console.log(this.movies);
+  }
+
+  removeScreeningFromEvent(movie: EWMovieItem, screening: Screening) {
+    //let film : EWMovieItem = this.deepCopy<EWMovieItem>(movie);
+    //let selection: Screening = this.deepCopy<Screening>(screening);
+    console.log(movie);
+    console.log(screening);
+    for (let i = this.movies.length - 1; i >= 0; --i) {
+      console.log(typeof this.movies[i].shows[0].show![0].screeningid);
+      console.log(typeof screening.screeningid);
+      console.log(JSON.stringify(this.movies[i].shows[0].show![0].screeningid) == JSON.stringify(screening.screeningid));
+      if (JSON.stringify(this.movies[i].shows[0].show![0].screeningid) == JSON.stringify(screening.screeningid)) {
+        this.movies.splice(i,1);
+      }
+    }
+    console.log(this.movies);
+  }
+
+
   removeMovieFromEvent(ewMovieItem: EWMovieItem) {
     for (let i = this.movies.length - 1; i >= 0; --i) {
       if (this.movies[i] == ewMovieItem) {
@@ -46,6 +84,37 @@ export class EventService {
     
   }
 
+  
+  deepCopy<T>(instance : T) : T {
+    if ( instance == null){
+        return instance;
+    }
+
+    // handle Dates
+    if (instance instanceof Date) {
+        return new Date(instance.getTime()) as any;
+    }
+
+    // handle Array types
+    if (instance instanceof Array){
+        var cloneArr = [] as any[];
+        (instance as any[]).forEach((value)  => {cloneArr.push(value)});
+        // for nested objects
+        return cloneArr.map((value: any) => this.deepCopy<any>(value)) as any;
+    }
+    // handle objects
+    if (instance instanceof Object) {
+        var copyInstance = { ...(instance as { [key: string]: any }
+        ) } as { [key: string]: any };
+        for (var attr in instance) {
+            if ( (instance as Object).hasOwnProperty(attr)) 
+                copyInstance[attr] = this.deepCopy<any>(instance[attr]);
+        }
+        return copyInstance as T;
+    }
+    // handling primitive data types
+    return instance;
+}
 }
 
 

--- a/src/app/event/event.component.html
+++ b/src/app/event/event.component.html
@@ -77,15 +77,15 @@
 <!-- GRID TO DISPLAY MOVIES -->
 <div class="content">
   <div fxLayout="row wrap" fxLayoutGap="16px grid">
-    <div class="content" *ngFor="let movie of eventMovies">
+    <div class="content" fxFlex="20%" fxFlex.xs="100%" fxFlex.sm="33%" *ngFor="let movie of eventMovies">
       <app-movie-card [movie]="movie"> </app-movie-card>
-      <div class="movieTitle">{{ movie.title }}</div>
+      <!-- <div class="movieTitle">{{ movie.title }}</div> -->
       <!-- <div class="movieTitle">{{ if (movie.shows.show[0].timestamp || movie.shows.show }}</div> -->
       <!-- <div class="moviesTitle">{{ Object.prototype.toString.call(movie.shows.show) !== '[object Array]' ? [movie.shows.show] : movie.shows.show[0].timestamp }}</div> -->
       <!-- if shows is an array, then show the first one, otherwise show the single show -->
-      <div class="moviesTitle" *ngFor="let item of movie.shows[0].show"> <!-- {{ movie.shows[0].show[0].timestamp }}</div> -->
-          <div class="moviesTitle">{{ unixConvert(item.timestamp) }} - Screen {{item.screen}}</div>
-      </div>
+      <!-- <div class="moviesTitle" *ngFor="let item of movie.shows[0].show">--> <!-- {{ movie.shows[0].show[0].timestamp }}</div> -->
+          <!--<div class="moviesTitle">{{ unixConvert(item.timestamp) }} - Screen {{item.screen}}</div>
+      </div> -->
       <!-- <div class="moviesTitle">{{ movie.shows.show[0].timestamp ? movie.shows.show[0].timestamp : movie.shows }}</div> -->
     </div>
   </div>

--- a/src/app/movieCard/movieCard.component.html
+++ b/src/app/movieCard/movieCard.component.html
@@ -1,18 +1,35 @@
-<mat-card *ngIf="movie" class="movie-card" (click)="onSelectCard(movie)" [ngClass]="{'card-selected mat-elevation-z4': selected}" (deferLoad)="show = true">
+<mat-card *ngIf="movie" class="movie-card"  (deferLoad)="show = true"> <!-- (click)="onSelectCard(movie)"-->
   <div class="content">
-  <span [matTooltip]="selected ? 'true' : 'false'" class="selection">
+  <!-- <span [matTooltip]="selected ? 'true' : 'false'" class="selection">
     <mat-icon>check_circle</mat-icon>
-  </span>
+  </span> -->
   <mat-card-header>
     <!--<mat-card-title>{{movie.title}}</mat-card-title>-->
   </mat-card-header>
   <ng-container *ngIf="show">
     <!--<img mat-card-image src="{{movie.image}}" alt="Movie Poster for {{movie.title}}">-->
     <img mat-card-image src="{{movie.poster}}" alt="Movie Poster for {{movie.title}}">
-    <p>{{movie.releasedate}}</p>
-    <!-- <button mat-raised-button color="primary" (click)="onSelectCard(movie)">
-      {{movie.shows.show[0].room}}
-    </button> -->
+    <p>{{movie.title}}</p>
+    <!-- <div fxLayout="row wrap" fxLayoutGap="16px grid"> -->
+      <div class="screenings">
+        <div class="screenings-buttons" *ngFor="let item of movie.shows[0].show"> <!-- {{ movie.shows[0].show[0].timestamp }}</div> -->
+          <!-- <button mat-button (click)="onSelectScreening(item)"> -->
+            <app-screen-button [item]="item" [movie]="movie"></app-screen-button>
+
+
+<!--            
+          <ng-container *ngIf="movie.shows[0].show.length === 1 else buttongrid">
+            <button mat-raised-button color="primary" class="single-screening">{{ unixConvert(item.timestamp) }} - Screen {{item.screen}}
+            </button>
+          </ng-container>
+          <ng-template #buttongrid>
+            <button mat-raised-button color="primary" class="buttongrid" (click)="onSelectCard(movie)">{{ unixConvert(item.timestamp) }} - Screen {{item.screen}}
+            </button>
+        </ng-template>
+      -->
+       </div>
+
+    </div>
   </ng-container>
 </div>
 </mat-card>

--- a/src/app/movieCard/movieCard.component.scss
+++ b/src/app/movieCard/movieCard.component.scss
@@ -1,7 +1,7 @@
 .movie-card {
   //padding: auto;
-  width: 188px;
-  height: 338px;
+  max-width: 1000px;
+  //max-height: 600px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -9,8 +9,8 @@
 }
 
 img {
-  max-height: 100%;
-  max-width: 100%;
+  max-height: 80%;
+  max-width: 80%;
   margin: auto;
   display: block;
   //overflow: hidden;
@@ -29,8 +29,41 @@ mat-card:hover .selection {
 mat-card.mat-elevation-z4 .selection {
   opacity: 1;
 }
-.card-selected {
-  border: 4px solid #283593;
+
+.screenings {
+  padding-top: 5px; 
+  //display: grid;
+  //grid-template-columns: 
+   //[left] 1fr [right]1fr;
+  //justify-content: center;
+  //align-items: center;
+}
+.buttongrid {
+  margin: 2px 0px;
+  //position: absolute;
+  //top: 50%;
+  //-ms-transform: translateY(-50%);
+  //transform: translateY(-50%);
+  padding: 0px 5px;
+  width: 100%;
+  height: 100%;
+  font-size: smaller;
+  //font-weight: bold;
+  //background-color: #3f51b5;
+  background-color: red;
+  color: white;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  
+  //justify-content: center;
+  //align-items: center;
+  
+}
+
+
+.button-selected {
+  border: 2px solid #283593;
 }
 
 .selection {

--- a/src/app/movies.ts
+++ b/src/app/movies.ts
@@ -44,7 +44,7 @@ export interface EWMovieItem {
     releasedate: string;
     runtime: string;
     series: string;
-    shows: Shows[];
+    shows: Shows[];  //[];
     synopsis: string;
     title: string;
     type: string;
@@ -53,7 +53,7 @@ export interface EWMovieItem {
 }
 
 export interface Shows {
-    show: any[];
+    show: any[] | null;
 }
 
 export interface Screening {

--- a/src/app/screen-button/screen-button.component.html
+++ b/src/app/screen-button/screen-button.component.html
@@ -1,0 +1,11 @@
+<div *ngIf="item" class="movie-card"  (deferLoad)="show = true">
+    <span [matTooltip]="buttonSel ? 'true' : 'false'" class="selection">
+        <mat-icon>check_circle</mat-icon>
+    </span>
+    <ng-container *ngIf="show">
+        <button mat-raised-button color="primary" class="buttongrid" (click)="onSelectScreening(item, movie)" [ngClass]="{'button-selected mat-elevation-z4': buttonSel}">
+            {{ unixConvert(item.timestamp) }} - Screen {{item.screen}}
+        </button>
+    </ng-container>
+    
+</div> 

--- a/src/app/screen-button/screen-button.component.scss
+++ b/src/app/screen-button/screen-button.component.scss
@@ -1,0 +1,58 @@
+// start movie selection styles
+mat-card:hover .selection {
+    opacity: 1;
+  }
+  mat-card.mat-elevation-z4 .selection {
+    opacity: 1;
+  }
+  
+  .screenings {
+    padding-top: 5px; 
+    //display: grid;
+    //grid-template-columns: 
+     //[left] 1fr [right]1fr;
+    //justify-content: center;
+    //align-items: center;
+  }
+  .buttongrid {
+    margin: 2px 0px;
+    //position: absolute;
+    //top: 50%;
+    //-ms-transform: translateY(-50%);
+    //transform: translateY(-50%);
+    padding: 0px 5px;
+    width: 100%;
+    height: 100%;
+    font-size: smaller;
+    //font-weight: bold;
+    //background-color: #3f51b5;
+    background-color: red;
+    color: white;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    
+    //justify-content: center;
+    //align-items: center;
+    
+  }
+  
+  
+  .button-selected {
+    border: 3px solid #283593;
+  }
+  
+  .selection {
+    opacity: 0;
+    cursor: pointer;
+    color: #283593;
+    background: white;
+    position: absolute;
+    right: -10px;
+    top: -10px;
+    border-radius: 100%;
+    height: 24px;
+    width: 24px;
+  }
+  // end movie selection styles
+  

--- a/src/app/screen-button/screen-button.component.spec.ts
+++ b/src/app/screen-button/screen-button.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ScreenButtonComponent } from './screen-button.component';
+
+describe('ScreenButtonComponent', () => {
+  let component: ScreenButtonComponent;
+  let fixture: ComponentFixture<ScreenButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ScreenButtonComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ScreenButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/screen-button/screen-button.component.ts
+++ b/src/app/screen-button/screen-button.component.ts
@@ -1,35 +1,34 @@
 import {Component, Input, OnInit, Output, EventEmitter} from '@angular/core';
 import {PopMovieItem, EWMovieItem, Screening} from "../movies";
 import { EventService } from "../event.service";
-//import {screen-button} from "../event/event.component";
 
 @Component({
-  selector: 'app-movie-card',
-  templateUrl: './movieCard.component.html',
-  styleUrls: ['./movieCard.component.scss']
+  selector: 'app-screen-button',
+  templateUrl: './screen-button.component.html',
+  styleUrls: ['./screen-button.component.scss']
 })
-export class MovieCardComponent implements OnInit {
-  @Input() movie!: EWMovieItem|undefined;
-  @Input() screening!: Screening|undefined;
+export class ScreenButtonComponent implements OnInit {
+  @Input() movie!: EWMovieItem;
+  @Input() item!: Screening|undefined;
   @Output() notify = new EventEmitter();
 
   show = false;
-  selected = false;
-  buttonSel = false
-  constructor(
-    private eventService: EventService
-  ) {}
+  buttonSel = false;
 
-  onSelectCard(ewMovieItem: EWMovieItem) {
-    this.selected = !this.selected;
-    console.log(this.selected);
-    if (this.selected == false) {
-      this.eventService.removeMovieFromEvent(ewMovieItem);
-    } else {
-      this.eventService.addMovieToEvent(ewMovieItem);
+  constructor(private eventService: EventService) { }
+
+  onSelectScreening(screening: Screening, movie: EWMovieItem) {
+    this.buttonSel = !this.buttonSel;
+    console.log(this.buttonSel);
+    if (this.buttonSel == false) {
+      console.log("remove screening: " + JSON.stringify(screening));
+      this.eventService.removeScreeningFromEvent(movie, screening);
+  } else {
+      console.log("add screening: " + JSON.stringify(screening));
+      console.log("add movie: " + JSON.stringify(movie));
+      this.eventService.addScreeningToEvent(movie, screening);
     }
   }
-  
 
   unixConvert(unix: string): string {
     let show = new Date(parseInt(unix) * 1e3).toISOString().substring(0, 23);


### PR DESCRIPTION
This update includes a button component for individual screening times, which are now the selectable option instead of the overall movie card component. Screening times can successfully be added to or removed from the event info, and the event details are successfully saved to the event db.

_Based on continuing conversations, this may not be how we want to proceed, instead selecting a day, and displaying only the movies/screenings for that selected date. the host would only select the day (and possible a time range), then all shown elements would just "be" the event selections._  

**Based on that, this PR may not be needed?**  