### PR TITLE
Mpg m4 timerange filtered movies

### DIFF
--- a/src/app/event.service.ts
+++ b/src/app/event.service.ts
@@ -10,7 +10,11 @@ export class EventService {
   constructor(private http: HttpClient) {}
 
   getNumSelected() {
-    return this.movies.length;
+    let count = 0;
+    this.movies.forEach(movie=> count += movie.shows[0].show.length);
+    //return this.movies.length;
+    console.log("getNumSelected: ", count);
+    return count;
   }
 
   getSelectedMovies() {

--- a/src/app/event/event.component.html
+++ b/src/app/event/event.component.html
@@ -51,6 +51,10 @@
         <button mat-fab class="filter" (click)="filterMoviesByTime('evening')" color="accent">5pm-Mid</button>
       </div>
 
+      <div class="filter-button-row">
+        <button mat-stroked-button class="clearfilter" (click)="resetFilters()">Clear time ranges</button>
+      </div>
+
       <h3 style="color: red">
         {{ errormsg }}
       </h3>
@@ -95,18 +99,31 @@
   <!-- GRID TO DISPLAY MOVIES -->
     <div class="content">
       <div fxLayout="row wrap" fxLayoutGap="16px grid">
-        <div *ngIf="eventDate !== ''; else elseBlock">
-          <div class="content" *ngFor="let movie of filteredMovies">
-            <app-movie-card [movie]="movie"> </app-movie-card>
-            <div class="movieTitle">{{ movie.title }}</div>
+        <div *ngIf="eventDate !== ''; else elseBlock;">
+          <ng-container *ngIf="timeFilteredMovies.length > 0; then timeFilt; else altBlock;"></ng-container>
+            <ng-template #timeFilt> 
+            <div class="content" *ngFor="let movie of timeFilteredMovies">
+              <app-movie-card [movie]="movie"> </app-movie-card>
+              <div class="movieTitle">{{ movie.title }}</div>
+              <div class="moviesTitle" *ngFor="let item of movie.shows[0].show">
+                <div class="moviesTitle">{{ unixConvert(item.timestamp) }} - Screen {{item.screen}}</div>
+              </div>
+            </div>
+          </ng-template>
+          <ng-template #altBlock>
+            <div class="content" *ngFor="let movie of filteredMovies">
+              <app-movie-card [movie]="movie"> </app-movie-card>
+              <div class="movieTitle">{{ movie.title }}</div>
             <!-- <div class="movieTitle">{{ if (movie.shows.show[0].timestamp || movie.shows.show }}</div> -->
             <!-- <div class="moviesTitle">{{ Object.prototype.toString.call(movie.shows.show) !== '[object Array]' ? [movie.shows.show] : movie.shows.show[0].timestamp }}</div> -->
             <!-- if shows is an array, then show the first one, otherwise show the single show -->
-            <div class="moviesTitle" *ngFor="let item of movie.shows[0].show"> <!-- {{ movie.shows[0].show[0].timestamp }}</div> -->
-                <div class="moviesTitle" *ngIf="unixConvert(item.timestamp).substring(0,11) === eventDate.substring(0,11)">{{ unixConvert(item.timestamp) }} - Screen {{item.screen}}</div>
+                <div class="moviesTitle" *ngFor="let item of movie.shows[0].show"> <!-- {{ movie.shows[0].show[0].timestamp }}</div> -->
+                  <div class="moviesTitle" *ngIf="unixConvert(item.timestamp).substring(0,11) === eventDate.substring(0,11)">{{ unixConvert(item.timestamp) }} - Screen {{item.screen}}</div>
+                </div>
             </div>
+          </ng-template>
+          
           </div>
-        </div>
         <ng-template #elseBlock>
           <div class="content" *ngFor="let movie of eventMovies">
             <app-movie-card [movie]="movie"> </app-movie-card>
@@ -121,6 +138,7 @@
           </div>
         </ng-template>
       </div>
-    </div>
+      </div>
+    <!--</div>-->
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/event/event.component.html
+++ b/src/app/event/event.component.html
@@ -10,7 +10,7 @@
 </div>
 <mat-sidenav-container class="example-container">
   <mat-sidenav mode="side" opened class="example-sidenav" >
-
+    
     <!--<div class="fixedNav">
       
       <app-topNav></app-topNav>
@@ -18,6 +18,7 @@
     <div class="fixedHead">
     <!--   <p>Logged in HostID: {{ sessionhostID }}</p>
     -->
+    <h3>Select a date for your Event to see what's playing that day!</h3>
       <div class="desktop">
         <p>
           <!-- <mat-form-field appearance="fill">
@@ -27,9 +28,9 @@
           </mat-form-field>
         -->
         </p>
-
+        
         <mat-form-field appearance="fill">
-          <mat-label>Choose a Date</mat-label>
+          <mat-label id="default">Choose a Date</mat-label>
           <input
             matInput
             [min]="minDate"
@@ -41,7 +42,14 @@
         </mat-form-field>
       </div>
 
-      <h3>Select a date for your Event to see what's playing that day!</h3>
+      <h3>Filter the selected day by time ranges, if desired!</h3>
+
+      <!-- Angular Material button examples -->
+      <div class="example-button-row">
+        <button mat-fab class="filter" (click)="filterMoviesByTime('morning')">8am-Noon</button>
+        <button mat-fab class="filter" (click)="filterMoviesByTime('afternoon')" color="primary">Noon-5pm</button>
+        <button mat-fab class="filter" (click)="filterMoviesByTime('evening')" color="accent">5pm-Mid</button>
+      </div>
 
       <h3 style="color: red">
         {{ errormsg }}

--- a/src/app/event/event.component.scss
+++ b/src/app/event/event.component.scss
@@ -41,14 +41,14 @@ app-topnav {
 }
 
 mat-form-field {
-  padding-top: 15%;
+  padding-top: 5%;
   width: 90%;
 
 
 }
 
 h3 {
-  padding: 0 5%;
+  padding: 5%;
 }
 .fixedHead {
     top: 37px;
@@ -97,7 +97,10 @@ mat-datepicker-toggle {
   z-index: 9999;
 }
 
-
+.filter {
+  font-size: smaller;
+  margin: 0px 3px;
+}
 
 
 

--- a/src/app/event/event.component.scss
+++ b/src/app/event/event.component.scss
@@ -102,7 +102,14 @@ mat-datepicker-toggle {
   margin: 0px 3px;
 }
 
+.filter-button-row {
+  padding: 5%;
+}
 
+.clearfilter {
+  font-size: smaller;
+  margin: 3px;
+}
 
 .clickable {
   cursor: pointer;

--- a/src/app/event/event.component.ts
+++ b/src/app/event/event.component.ts
@@ -59,6 +59,7 @@ export class EventComponent implements OnInit {
   date = new FormControl(new Date());
   gridColumns = 3;
   minDate = new Date();
+  rangeActive = false;
   //objCheck: Shows[] = [];
 
   constructor(public apicall: ApicallService, private eventService: EventService, private httpClient: HttpClient) {}
@@ -181,8 +182,12 @@ export class EventComponent implements OnInit {
   //filter all movies based on selected date
   // will update the shows[0].show scrrenings array with just the ones for the date selected
   filterMovies(eventDate: string) {
+    // clear timefiltered selections from a previous date selection
+    if (this.timeFilteredMovies.length > 0) {
+      this.timeFilteredMovies.length = 0;
+    }
     console.log('filteredMovies() triggered')
-    let filtered = this.eventMovies;
+    let filtered: EWMovieItem[] = JSON.parse(JSON.stringify(this.eventMovies));
     let target = eventDate.substring(0,11);
     console.log('target date: ', target)
     // this will filter for the selected date:
@@ -226,7 +231,7 @@ export class EventComponent implements OnInit {
       return;
     }
     let targetRange = '';
-    let timeFiltered = this.filteredMovies;
+    let timeFiltered: EWMovieItem[] = JSON.parse(JSON.stringify(this.filteredMovies));
     let start: number, end: number;
     let ranges:number[] = [];
     if (range === "morning") {
@@ -260,6 +265,12 @@ export class EventComponent implements OnInit {
       console.log("time filtered: ", this.timeFilteredMovies);
       console.log("original filtered: ", this.filteredMovies);
     
+  }
+
+  resetFilters() {
+    this.timeFilteredMovies.length = 0;
+    this.filterMovies(this.eventDate);
+    console.log('filters reset');
   }
 
   confmessage(): void {
@@ -321,8 +332,15 @@ export class EventComponent implements OnInit {
     this.date = new FormControl(new Date());
     //this.labelReset();
     this.eventService.resetMovieArray();
+    this.filteredMovies.length = 0;
+    this.timeFilteredMovies.length = 0;
+    this.loadEWMovies();
     this.confmsg = `Your event for "${newEvent.eventDate}" has been created!`;
     this.confmessage();
+    console.log("timefilt: ", this.timeFilteredMovies);
+    console.log("datefilt: ", this.filteredMovies);
+    console.log('date',this.eventDate);
+    console.log('selectedMovs', this.selectedMovies);
     //return newEvent;
   }
 

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -37,55 +37,64 @@
         <tr>
           <!-- <th scope="col">Event ID</th> -->
           <th scope="col">Event Date</th>
-          <th scope="col">Date</th>
+          <!-- <th scope="col">Date</th> -->
           <th scope="col">Movies</th>
-          <th scope="col">Votes Submitted</th>
           <th scope="col">Invite Guests</th>
+          <th scope="col">Votes Submitted</th>
+          <th scope="col">Delete Event</th>
         </tr>
       </thead>
       <tbody>
         <tr *ngFor="let viewing of movieEvents">
+          <!-- <div *ngIf="viewing.eventDate<this.today"> -->
           <!-- <td>{{ viewing.id }}</td> -->
           <td>
             <a
               mat-raised-button
-              color="warn"
+              color="basic"
               [routerLink]="['/ranking', viewing.id]"
               >{{ viewing.eventDate }}</a
             >
           </td>
-          <td>{{ viewing.eventDate }}</td>
+          <!-- <td>{{ viewing.eventDate }}</td> -->
           <td>
             <ul class="movies" *ngFor="let movie of viewing.eventMovies">
               <li>{{ movie.title }}</li>
             </ul>
           </td>
-          <!-- <td *ngIf="viewing.eventRankings; else dispZero">
-            {{ viewing.eventRankings?.length }}
-          </td> -->
+          
+          <td>
+            <a
+              mat-raised-button
+              color="primary"
+              href="mailto:?subject=You\'ve%20been%20invited%20to%20a%20gathering%20at%20Circle%20Cinema%20on%20'{{
+                viewing.eventDate
+              }}'&body=This tool will allow you to select which screenings are your favorites!%0A The movies showing on {{viewing.eventDate}} are:%0A{{viewing.eventMovies}}
+              
+              Before%20{{
+                viewing.eventDate
+              }},%20rank%20the%20screening%20options%20at:%0A%0A{{ this.url }}{{
+                viewing.id
+              }}%0A%0AThanks!"
+            >
+              Invite
+            </a>
+          </td>
           <td *ngIf="viewing.eventRankings; else dispZero">
+            {{ viewing.eventRankings?.length }}
+          </td>
+          <!-- <td *ngIf="viewing.eventRankings; else dispZero">
             <ul class="no-bullets" *ngFor="let ranking of viewing.eventRankings">
               <li>{{ ranking.userID }}</li>
             </ul>
-          </td>
+          </td> -->
           <ng-template #dispZero>
             <td>0</td>
           </ng-template>
           <td>
-            <a
-              mat-raised-button
-              color="accent"
-              href="mailto:?subject=Vote%20for%20which%20movie%20to%20watch%20on%20'{{
-                viewing.eventDate
-              }}'&body=Before%20{{
-                viewing.eventDate
-              }},%20rank%20the%20movies%20at:%0A%0A{{ this.url }}{{
-                viewing.id
-              }}%0A%0AThanks!"
-            >
-              email
-            </a>
+            <a class="flex-item"><mat-icon>delete</mat-icon></a>
           </td>
+        <!-- </div> -->
         </tr>
       </tbody>
     </table>

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -43,7 +43,7 @@ caption {
 }
 thead,
 th {
-  background-color: #000;
+  background-color:darkolivegreen;
   color: #fff;
   border: 2px solid #fff;
   padding: 0.6em;
@@ -63,9 +63,14 @@ td {
   vertical-align: middle;
 }
 ul.movies {
+  list-style-type: none;
   text-align: left;
   margin: 1em;
   padding: 0;
+}
+
+ul.movies li::before {
+  content: "- ";
 }
 
 ul.no-bullets {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -27,8 +27,8 @@ export class HomeComponent implements OnInit {
   // url that gets sent in the email for users to rank selected movies in events
   //url = 'https://moviemeetup.com/ranking/';
   url = 'https://localhost:4200/ranking/';
-  today = '';
-  date = new Date();
+  //today: any;
+  //date = new Date();
 
   constructor(private eventComponent: EventComponent, public apicall: ApicallService, private router: Router, private rankingService: RankingService, private httpClient: HttpClient, private route: ActivatedRoute) {
     };
@@ -41,8 +41,8 @@ export class HomeComponent implements OnInit {
     this.rankingService.loadMovieEventsByHostID(String(sessionStorage.getItem('hostID')));
     this.movieEvents = this.rankingService.getMovieEvents();
      
-    this.today = this.eventComponent.unixConvert(this.date.toString());
-    console.log("today?: ", this.today);
+    //this.today = this.eventComponent.hoursConvert(this.date.getTime().toString());
+    //console.log("today?: ", this.today);
   }
 
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ApicallService } from '../apicall.service';
 import { HttpClient } from '@angular/common/http';
-import { MovieEvent } from '../event/event.component';
+import { MovieEvent, EventComponent } from '../event/event.component';
 import { RankingService } from '../ranking.service';
 import { environment } from 'src/environments/environment';
 import jwtDecode, { JwtPayload }  from "jwt-decode";
@@ -15,6 +15,7 @@ export interface JwtPayloadCognito extends JwtPayload {
 }
 
 @Component({
+  providers:[EventComponent],
   selector: 'app-home',
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss']
@@ -26,8 +27,10 @@ export class HomeComponent implements OnInit {
   // url that gets sent in the email for users to rank selected movies in events
   //url = 'https://moviemeetup.com/ranking/';
   url = 'https://localhost:4200/ranking/';
+  today = '';
+  date = new Date();
 
-  constructor(public apicall: ApicallService, private router: Router, private rankingService: RankingService, private httpClient: HttpClient, private route: ActivatedRoute) {
+  constructor(private eventComponent: EventComponent, public apicall: ApicallService, private router: Router, private rankingService: RankingService, private httpClient: HttpClient, private route: ActivatedRoute) {
     };
 
     
@@ -37,9 +40,9 @@ export class HomeComponent implements OnInit {
     console.log("session storage-host: "+ sessionStorage.getItem('hostID'));
     this.rankingService.loadMovieEventsByHostID(String(sessionStorage.getItem('hostID')));
     this.movieEvents = this.rankingService.getMovieEvents();
-
-    
-    
+     
+    this.today = this.eventComponent.unixConvert(this.date.toString());
+    console.log("today?: ", this.today);
   }
 
 }

--- a/src/app/ranking.service.ts
+++ b/src/app/ranking.service.ts
@@ -19,10 +19,14 @@ export class RankingService {
       for (let index in data) {
         // make sure the hostID equals the demoID, and that the id does not already exist in the movieEvents array
         if ((data[index].hostID == demoID) && (data[index].id != (this.movieEvents.find(event => event.id == data[index].id))?.id)) {
+          console.log(data[index].eventDate);
+          console.log(Date.parse(data[index].eventDate));
           this.movieEvents.push(data[index]);
         }
       }
     });
+ 
+    
     console.log('RankingService-getMovieEventsByHostID completed: ' + this.movieEvents); 
     return this.movieEvents;
   }
@@ -42,6 +46,12 @@ export class RankingService {
   }*/
 
   getMovieEvents(){
+    //this.movieEvents.sort((a,b) => (a.eventDate > b.eventDate) ? 1 : ((b.eventDate > a.eventDate) ? -1 : 0));
+    this.movieEvents.sort((a,b) => {
+      var dateA = Date.parse(a.eventDate);
+      var dateB = Date.parse(b.eventDate);
+      return dateA < dateB ? 1 : -1;
+    })
     return this.movieEvents;
   }
 }

--- a/src/app/ranking.service.ts
+++ b/src/app/ranking.service.ts
@@ -15,7 +15,7 @@ export class RankingService {
 
   loadMovieEventsByHostID(demoID: String): MovieEvent[] {
     this.apicall.getMovieEvents().subscribe((data) => {
-      //console.log(data);
+      console.log('lmebi: ', data);
       for (let index in data) {
         // make sure the hostID equals the demoID, and that the id does not already exist in the movieEvents array
         if ((data[index].hostID == demoID) && (data[index].id != (this.movieEvents.find(event => event.id == data[index].id))?.id)) {


### PR DESCRIPTION
This PR addresses the filtering of movies based on the date, as well as for time ranges: Morning(8-11:59am), Afternoon(Noon-4:59pm), and Evening(5pm-11:59pm), as well as homepage layout changes.

Following changes implemented:

- Homepage-removed name of event, using he date of the event as the button text for going to ranking page.
- Homepage-removed extraneous date field, host Id logged in text, adjusted submitted votes to just be numerical, moved the movie listings column o the left, and added a "delete" icon column.
- Event Page- sorts movies by date selected, and displays just the screenings for that date. Changing date will reset which movies/screenings are displayed (and resets the potential selected movie each time).
- Event Page-adds time range filters and reset time filters buttons.  These will filter out the date selected's screenings into a separate temp array, so that if time filter changes occur, are reset, or the date is changed, previous selections won't interfere.  I.E. selecting a date saves the date filtered movies, selecting a time range will save time range filtered movies, clearing the time filtered movies will result in the date filtered movies being displayed.
- Event Page-When the create event button is selected, the catch to ensure 3 movies has been updated to check for three total screenings instead, and just the screenings selected will get passed into the movie event table for ease of use with the ranking and finalranking pages.