### PR TITLE
Mpg m5 finalranking display elements

### DIFF
--- a/src/app/finalRanking/final-ranking.component.html
+++ b/src/app/finalRanking/final-ranking.component.html
@@ -12,8 +12,8 @@
         There is a {{ topChoices.length }}-way tie!
       </div>
       <div class="cardHeader">
-        {{ topChoices }}
-        <!--{{ finalRankings[0].title }}-->
+        <p>{{ topChoices }}</p>
+        <p>{{ this.rankingConvert(finalRankings[0].timestamp!) }}</p>
       </div>
       <mat-card *ngIf="rankings" class="movie-card">
         <!--<div class="content" *ngIf="finalRankings">
@@ -27,6 +27,7 @@
           />
         </div>
       </mat-card>
+      <a href="{{ finalRankings[0].screeninglink! }}" target="_blank">Buy Tickets!</a>
     </div>
   </ng-container>
 

--- a/src/app/finalRanking/final-ranking.component.html
+++ b/src/app/finalRanking/final-ranking.component.html
@@ -42,7 +42,7 @@
       <tbody>
         <ng-container *ngIf="rankings">
           <tr *ngFor="let movie of finalRankings; let i = index">
-            <td>{{ movie.title }}</td>
+            <td>{{ movie.title}} - {{ rankingConvert(movie.timestamp!) }} </td>
             <td class="points">{{ movie.points }}</td>
           </tr>
         </ng-container>

--- a/src/app/finalRanking/final-ranking.component.scss
+++ b/src/app/finalRanking/final-ranking.component.scss
@@ -40,13 +40,33 @@ table {
 
 .movie-card {
   //padding: auto;
-  width: 250px;
-  height: 450px;
+  width: 50%;
+  //width: 250px;
+  //height: 450px;
   display: flex;
   justify-content: center;
   align-items: center;
   background-color: #f5f5f5;
   margin: auto;
+}
+
+a {
+  margin: 1em;
+  padding: .5em 1em;
+  width: 50%;
+}
+a:link, a:visited {
+  background-color:darkgreen;
+  color: white;
+  font-weight:bold;
+  text-align:center;
+  text-decoration: none;
+  display: inline-block;
+  border-radius: 10px;
+}
+
+a:hover, a:active {
+  background-color: forestgreen;
 }
 
 .points {

--- a/src/app/finalRanking/final-ranking.component.ts
+++ b/src/app/finalRanking/final-ranking.component.ts
@@ -83,7 +83,7 @@ export class FinalRankingComponent implements OnInit {
   }
 
   checkPointTie() {
-    console.log("???", this.finalRankings[0].timestamp);
+    console.log("???", this.finalRankings[0].screeninglink!);
     let max = this.finalRankings[0].points;
     for (let finalRanking in this.finalRankings) {
       if (max == this.finalRankings[finalRanking].points) {

--- a/src/app/finalRanking/final-ranking.component.ts
+++ b/src/app/finalRanking/final-ranking.component.ts
@@ -38,7 +38,8 @@ export class FinalRankingComponent implements OnInit {
 
   constructor(
     public apicall: ApicallService, 
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private rankingService: RankingService
   ) {}
 
   ngOnInit() {
@@ -67,7 +68,7 @@ export class FinalRankingComponent implements OnInit {
 
       if (this.movieEvent.finalRankings != undefined) {
         this.finalRankings = this.movieEvent.finalRankings;
-        //console.log("finalRanking: ", this.finalRanking);
+        console.log("finalRanking: ", JSON.stringify(this.movieEvent.finalRankings));
       }
       
       if (this.movieEvent.id) {
@@ -82,6 +83,7 @@ export class FinalRankingComponent implements OnInit {
   }
 
   checkPointTie() {
+    console.log("???", this.finalRankings[0].timestamp);
     let max = this.finalRankings[0].points;
     for (let finalRanking in this.finalRankings) {
       if (max == this.finalRankings[finalRanking].points) {
@@ -89,6 +91,10 @@ export class FinalRankingComponent implements OnInit {
         console.log("top choices: ", this.topChoices);
       }
     }
+  }
+
+  rankingConvert(unix: string): string {
+    return this.rankingService.unixConvert(unix);
   }
 }
 

--- a/src/app/movies.ts
+++ b/src/app/movies.ts
@@ -49,7 +49,9 @@ export interface EWMovieItem {
     title: string;
     type: string;
     writer: string;
-    points?: number;   
+    points?: number;
+    timestamp?: string;
+    screeningid?: string;   
 }
 
 export interface Shows {

--- a/src/app/movies.ts
+++ b/src/app/movies.ts
@@ -51,7 +51,8 @@ export interface EWMovieItem {
     writer: string;
     points?: number;
     timestamp?: string;
-    screeningid?: string;   
+    screeningid?: string;
+    screeninglink?: string;   
 }
 
 export interface Shows {


### PR DESCRIPTION
This PR updates the finalrankings page elements to properly display the winning result poster, along with a ticket purchase link, as well as update the vote results table for each individual screening information instead of just the movies involved.

This latter aspect required updates to the getFinalRankings lambda function, as well as updates to the movies.ts file where the EWMovieItem Interface lives, as optional attributes needed for finalranking screenings was required.