### PR TITLE
updates gitignore and removes import from finalRanking resolve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ chrome-profiler-events*.json
 .history/*
 
 # misc
+/.angular/cache
 /.sass-cache
 /connect.lock
 /coverage

--- a/src/app/finalRanking.resolve.ts
+++ b/src/app/finalRanking.resolve.ts
@@ -1,4 +1,3 @@
-import { templateJitUrl } from "@angular/compiler";
 import { Injectable } from "@angular/core";  
 import { Resolve, ActivatedRouteSnapshot} from "@angular/router";  
 import { Observable } from "rxjs";  


### PR DESCRIPTION
latest attempt to push to heroku revealed new error regarding a templateJitUrl import on the finalRanking resolve.  This was grayed out, implying it wasn't being referenced. I deleted the import statement, launched the app to test it wasn't causing a problem. After a successful app launch and testing functionality, it appeared to be safe to remove.

This PR updates the main branch to reflect that import removal (and updates the gitignore file with a surprise addition of .angular/cache folder that appeared).