### PR TITLE
trying just plan ng build this time

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:ci": "ng build --sourceMap=false",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "heroku-postbuild": "ng build --aot --prod"
+    "heroku-postbuild": "ng build"
   },
   "engines": {
     "node": "16.11.1",


### PR DESCRIPTION
just going with plain 'ng build' for the heroku-postbuild line.  Looking up argument options for ng build, ther isn't a "--prod" option, which is likely why is keeps throwing invalid arguement errors.