### PR TITLE
Mpg m8 heroku deployment updates

### DIFF
--- a/src/app/topNav/topNav.component.html
+++ b/src/app/topNav/topNav.component.html
@@ -7,7 +7,7 @@
   <a
     class="logoutButton"
     
-    href="https://auth.moviemeetup.com/logout?client_id=3can93q53vqr18qoidsi1g65l7&logout_uri={{
+    href="https://cinema-meetup.auth.us-west-2.amazoncognito.com/logout?client_id=6ho65lnv4mnbt0pdgbrpe0t6ii&logout_uri={{
       logoutURL
     }}"
     mat-raised-button

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,9 +6,12 @@ export const environment = {
   production: false,
   imdbApiKey: "k_jr9zca59",
   demoUserID: "DEMO",
-  loginURL: "http://localhost:4200/home",
-  logoutURL: "http://localhost:4200/intro"
+  loginURL: "https://ike-easyware.herokuapp.com/home",
+  logoutURL: "https://ike-easyware.herokuapp.com/intro"
 };
+/* loginURL: "http://localhost:4200/home",
+  logoutURL: "http://localhost:4200/intro"
+*/
   
   /*
    * For easier debugging in development mode, you can import the following file


### PR DESCRIPTION
While testing the logout button, got a error on the Cognito logout screen with a message: "Required String parameter 'redirect_uri' is not present", which was odd, as it worked locally.  Loking close at the topnav's logout path--I thought just the environent fil needed to be updated, but it's possible more needs to be included--the logout was still referencing auth.moviemeetup, which is clearly incorrect.

However, in addition to that, it specifically asked for a redirect_uri, whereas the MMU version was just using "logout_uri".