### PR TITLE
typo fix on home page invite email text

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -39,7 +39,7 @@ export class HomeComponent implements OnInit {
   currentID: string = '';
   finEvent: MovieEvent | undefined
   //finurl = 'https://localhost:4200/finalranking/'
-  finurl = 'https://ike-easyware.herokuapp.com/finalranking'
+  finurl = 'https://ike-easyware.herokuapp.com/finalranking/'
   finTitle: string = '';
   finRoom: string = '';
   finTime: string = '';


### PR DESCRIPTION
examining production app, noticed the invite email's finurl variable was missing the "/" off the end. 